### PR TITLE
1.3

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -5,7 +5,7 @@ category = "TMX"
 perms = "paid"
 siteid = 124
 
-version = "1.2.2"
+version = "1.3"
 
 [script]
 imports = [ "Icons.as", "Permissions.as", "Dialogs.as" ]

--- a/src/Main.as
+++ b/src/Main.as
@@ -19,32 +19,6 @@ void RenderMenu()
 	}
 }
 
-void RenderMenuMain()
-{
-    if(UI::BeginMenu(MXColor + Icons::Random + " \\$z"+shortMXName+" Quick menu")) {
-        if (UI::MenuItem(MXColor + Icons::Random + " \\$zStart searching", "", isSearching)) {
-            if (!isTitePackLoaded()) {
-                vec4 color = UI::HSV(0.0, 0.5, 1.0);
-                UI::ShowNotification(Icons::Kenney::ButtonTimes + " No titlepack loaded", "Please enter in a titlepack.", color, 5000);
-            } else {
-                RandomMapProcess = true;
-                isSearching = !isSearching;
-            }
-		}
-        
-        UI::Separator();
-
-        if(UI::MenuItem(MXColor + Icons::Random + " \\$z"+shortMXName+" Randomizer Menu", "", menu_visibility)) {
-            menu_visibility = !menu_visibility;	
-        }
-        if(UI::MenuItem(MXColor + Icons::ExternalLink + " \\$zRandom Map Challenge")) {
-            OpenBrowserURL("https://flinkblog.de/RMC/");
-        }
-
-        UI::EndMenu();
-    }
-}
-
 void Main()
 {
     startnew(SearchCoroutine);

--- a/src/Main.as
+++ b/src/Main.as
@@ -4,6 +4,7 @@ bool isSearching = false;
 Json::Value RecentlyPlayedMaps;
 
 int loadMapId = 0;
+int loadMapIdWithJson = 0;
 int keyCodes = 0;
 int inputMapID;
 
@@ -29,6 +30,20 @@ void Main()
         if (loadMapId != 0) {
             DownloadAndLoadMap(loadMapId);
             loadMapId = 0;
+        }
+        if (loadMapIdWithJson != 0) {
+            Json::Value mapInfo = GetMap(loadMapIdWithJson);
+            if (mapInfo.GetType() == Json::Type::Object) {
+#if MP4
+                if (mapInfo["TitlePack"] == getTitlePack()) {
+#endif
+                    CreatePlayedMapJson(mapInfo);
+                    loadMapId = loadMapIdWithJson;
+#if MP4
+                } else error("You can't play a map from a different titlepack", mapInfo["TitlePack"]);
+#endif
+            } else error("Returned data is not valid", "Returned type is " + changeEnumStyle(tostring(mapInfo.GetType())));
+            loadMapIdWithJson = 0;
         }
     }
 }

--- a/src/Main.as
+++ b/src/Main.as
@@ -13,9 +13,6 @@ void RenderMenu()
     if(UI::MenuItem(MXColor + Icons::Random + " \\$z"+shortMXName+" Randomizer", "", Setting_Window_Show)) {
 		Setting_Window_Show = !Setting_Window_Show;	
 	}
-    if(UI::MenuItem(MXColor + Icons::Random + " \\$z"+shortMXName+" Randomizer (Minimal Window)", "", Setting_Window_Minimal)) {
-		Setting_Window_Minimal = !Setting_Window_Minimal;	
-	}
     if(UI::MenuItem(MXColor + Icons::ExternalLink + " \\$zRandom Map Challenge")) {
 		OpenBrowserURL("https://flinkblog.de/RMC/");
 	}

--- a/src/Main.as
+++ b/src/Main.as
@@ -1,8 +1,6 @@
 bool RandomMapProcess = false;
 bool isSearching = false;
 
-bool menu_visibility = false;
-
 Json::Value RecentlyPlayedMaps;
 
 int loadMapId = 0;
@@ -11,8 +9,11 @@ int inputMapID;
 
 void RenderMenu()
 {
-    if(UI::MenuItem(MXColor + Icons::Random + " \\$z"+shortMXName+" Randomizer", "", menu_visibility)) {
-		menu_visibility = !menu_visibility;	
+    if(UI::MenuItem(MXColor + Icons::Random + " \\$z"+shortMXName+" Randomizer", "", Setting_Window_Show)) {
+		Setting_Window_Show = !Setting_Window_Show;	
+	}
+    if(UI::MenuItem(MXColor + Icons::Random + " \\$z"+shortMXName+" Randomizer (Minimal Window)", "", Setting_Window_Minimal)) {
+		Setting_Window_Minimal = !Setting_Window_Minimal;	
 	}
     if(UI::MenuItem(MXColor + Icons::ExternalLink + " \\$zRandom Map Challenge")) {
 		OpenBrowserURL("https://flinkblog.de/RMC/");

--- a/src/Main.as
+++ b/src/Main.as
@@ -1,7 +1,7 @@
 bool RandomMapProcess = false;
 bool isSearching = false;
 
-bool menu_visibility = true;
+bool menu_visibility = false;
 
 Json::Value RecentlyPlayedMaps;
 
@@ -17,6 +17,32 @@ void RenderMenu()
     if(UI::MenuItem(MXColor + Icons::ExternalLink + " \\$zRandom Map Challenge")) {
 		OpenBrowserURL("https://flinkblog.de/RMC/");
 	}
+}
+
+void RenderMenuMain()
+{
+    if(UI::BeginMenu(MXColor + Icons::Random + " \\$z"+shortMXName+" Quick menu")) {
+        if (UI::MenuItem(MXColor + Icons::Random + " \\$zStart searching", "", isSearching)) {
+            if (!isTitePackLoaded()) {
+                vec4 color = UI::HSV(0.0, 0.5, 1.0);
+                UI::ShowNotification(Icons::Kenney::ButtonTimes + " No titlepack loaded", "Please enter in a titlepack.", color, 5000);
+            } else {
+                RandomMapProcess = true;
+                isSearching = !isSearching;
+            }
+		}
+        
+        UI::Separator();
+
+        if(UI::MenuItem(MXColor + Icons::Random + " \\$z"+shortMXName+" Randomizer Menu", "", menu_visibility)) {
+            menu_visibility = !menu_visibility;	
+        }
+        if(UI::MenuItem(MXColor + Icons::ExternalLink + " \\$zRandom Map Challenge")) {
+            OpenBrowserURL("https://flinkblog.de/RMC/");
+        }
+
+        UI::EndMenu();
+    }
 }
 
 void Main()

--- a/src/Methods.as
+++ b/src/Methods.as
@@ -263,7 +263,7 @@ void CreatePlayedMapJson(Json::Value mapData) {
     string mapUid = mapData["TrackUID"];
     string titlepack = mapData["TitlePack"];
     string style = "Unknown";
-    if (mapData["Style"].GetType() == Json::Type::String) style = mapData["StyleName"];
+    if (mapData["StyleName"].GetType() == Json::Type::String) style = mapData["StyleName"];
     int awards = mapData["AwardCount"];
 
     Json::Value playedAt = Json::Object();

--- a/src/Methods.as
+++ b/src/Methods.as
@@ -102,13 +102,21 @@ Json::Value GetRandomMap() {
     req.Body = "";
     Json::Type returnedType = Json::Type::Null;
     Json::Value json;
-    while (returnedType != Json::Type::Object) {
+    string mapType = "";
+    while (returnedType != Json::Type::Object ||
+#if MP4
+    mapType != "Race"
+#elif TMNEXT
+    mapType != "TM_Race"
+#endif
+    ) {
         req.Start();
         while (!req.Finished()) {
             yield();
         }
         json = ResponseToJSON(req.String());
         returnedType = json.GetType();
+        mapType = json["results"][0]["MapType"];
         if (returnedType != Json::Type::Object) error("Warn: returned JSON is not valid, retrying", "Returned type is " + changeEnumStyle(tostring(returnedType)));
     }
     return json["results"][0];
@@ -254,7 +262,7 @@ void CreatePlayedMapJson(Json::Value mapData) {
     string mapAuthor = mapData["Username"];
     string mapUid = mapData["TrackUID"];
     string titlepack = mapData["TitlePack"];
-    string style = "";
+    string style = "Unknown";
     if (mapData["Style"].GetType() == Json::Type::String) style = mapData["StyleName"];
     int awards = mapData["AwardCount"];
 

--- a/src/Methods.as
+++ b/src/Methods.as
@@ -254,7 +254,8 @@ void CreatePlayedMapJson(Json::Value mapData) {
     string mapAuthor = mapData["Username"];
     string mapUid = mapData["TrackUID"];
     string titlepack = mapData["TitlePack"];
-    string style = mapData["StyleName"];
+    string style = "";
+    if (mapData["Style"].GetType() == Json::Type::String) style = mapData["StyleName"];
     int awards = mapData["AwardCount"];
 
     Json::Value playedAt = Json::Object();

--- a/src/Methods.as
+++ b/src/Methods.as
@@ -138,7 +138,7 @@ Json::Value GetMap(int mapId) {
         returnedType = json.GetType();
         if (returnedType != Json::Type::Array) error("Warn: returned JSON is not valid, retrying", "Returned type is " + changeEnumStyle(tostring(returnedType)));
     }
-    if (json.get_Length() < 1) return error("Map not found with this ID", "Empty array returned");
+    if (json.get_Length() < 1) return json;
     else return json[0];
 }
 

--- a/src/Methods.as
+++ b/src/Methods.as
@@ -138,7 +138,8 @@ Json::Value GetMap(int mapId) {
         returnedType = json.GetType();
         if (returnedType != Json::Type::Array) error("Warn: returned JSON is not valid, retrying", "Returned type is " + changeEnumStyle(tostring(returnedType)));
     }
-    return json[0];
+    if (json.get_Length() < 1) return error("Map not found with this ID", "Empty array returned");
+    else return json[0];
 }
 
 Json::Value ResponseToJSON(const string &in HTTPResponse) {

--- a/src/Methods.as
+++ b/src/Methods.as
@@ -134,6 +134,9 @@ Json::Value GetMap(int mapId) {
     Json::Value json;
     while (returnedType != Json::Type::Array) {
         req.Start();
+        while (!req.Finished()) {
+            yield();
+        }
         json = ResponseToJSON(req.String());
         returnedType = json.GetType();
         if (returnedType != Json::Type::Array) error("Warn: returned JSON is not valid, retrying", "Returned type is " + changeEnumStyle(tostring(returnedType)));

--- a/src/Settings.as
+++ b/src/Settings.as
@@ -39,5 +39,8 @@ enum MapType
 [Setting name="Map type" category="Searching"]
 MapType Setting_MapType = MapType::Anything;
 
-[Setting name="Window default height" category="Menu"]
+[Setting name="Minimal mode" category="Menu" description="In minimal mode, the window only shows a 'Start searching' button and nothing else. It also always shows even if the Openplanet overlay is closed"]
+bool Setting_Window_Minimal = false;
+
+[Setting name="Window default height" category="Menu" description="The default height of the window (does not affect in minimal mode)"]
 int Setting_WindowSize_h = 450;

--- a/src/Settings.as
+++ b/src/Settings.as
@@ -1,3 +1,20 @@
+[Setting name="Show window" category="Menu"]
+bool Setting_Window_Show = true;
+
+enum WindowType {
+    Full,
+    Minimal
+}
+
+[Setting name="Window type" category="Menu" description="The minimal window only shows a 'Start searching' button and nothing else."]
+WindowType Setting_Window_Type = WindowType::Full;
+
+[Setting name="Window default width" category="Menu" description="The default width of the main window" drag min=550 max=2000]
+int Setting_WindowSize_w = 650;
+
+[Setting name="Window default height" category="Menu" description="The default height of the main window" drag min=140 max=2000]
+int Setting_WindowSize_h = 450;
+
 enum MapLength
 {
     Anything = -1,
@@ -38,12 +55,3 @@ enum MapType
 
 [Setting name="Map type" category="Searching"]
 MapType Setting_MapType = MapType::Anything;
-
-[Setting name="Show window" category="Menu"]
-bool Setting_Window_Show = false;
-
-[Setting name="Minimal window" category="Menu" description="The minimal window only shows a 'Start searching' button and nothing else. To adjust the position of the window, click and drag the window border (not the button)."]
-bool Setting_Window_Minimal = false;
-
-[Setting name="Window default height" category="Menu" description="The default height of the main window"]
-int Setting_WindowSize_h = 450;

--- a/src/Settings.as
+++ b/src/Settings.as
@@ -39,8 +39,11 @@ enum MapType
 [Setting name="Map type" category="Searching"]
 MapType Setting_MapType = MapType::Anything;
 
-[Setting name="Minimal mode" category="Menu" description="In minimal mode, the window only shows a 'Start searching' button and nothing else. It also always shows even if the Openplanet overlay is closed"]
+[Setting name="Show window" category="Menu"]
+bool Setting_Window_Show = false;
+
+[Setting name="Minimal window" category="Menu" description="The minimal window only shows a 'Start searching' button and nothing else. To adjust the position of the window, click and drag the window border (not the button)."]
 bool Setting_Window_Minimal = false;
 
-[Setting name="Window default height" category="Menu" description="The default height of the window (does not affect in minimal mode)"]
+[Setting name="Window default height" category="Menu" description="The default height of the main window"]
 int Setting_WindowSize_h = 450;

--- a/src/UI.as
+++ b/src/UI.as
@@ -4,7 +4,7 @@ int rand = 0;
 void RenderInterface() {
     Dialogs::RenderInterface();
 	if (Setting_Window_Minimal) {
-        if (UI::Begin(MXColor + Icons::Random, Setting_Window_Minimal, 2097154+32+64+1)) {
+        if (UI::Begin(MXColor + Icons::Random, Setting_Window_Minimal, 2097154+32+64)) {
 #if TMNEXT
             if (!Permissions::PlayLocalMap()) UI::Text("\\$f00"+Icons::Times+" Missing permissions!");
             else {

--- a/src/UI.as
+++ b/src/UI.as
@@ -29,10 +29,16 @@ void RenderHeader() {
                     isSearching = !isSearching;
                 } else {
                     Json::Value mapInfo = GetMap(inputMapID);
-                    if (mapInfo["TitlePack"] == getTitlePack()) {
-                        CreatePlayedMapJson(mapInfo);
-                        loadMapId = inputMapID;
-                    } else error("You can't play a map from a different titlepack", mapInfo["TitlePack"]);
+                    if (mapInfo.GetType() == Json::Type::Object) {
+#if MP4
+                        if (mapInfo["TitlePack"] == getTitlePack()) {
+#endif
+                            CreatePlayedMapJson(mapInfo);
+                            loadMapId = inputMapID;
+#if MP4
+                        } else error("You can't play a map from a different titlepack", mapInfo["TitlePack"]);
+#endif
+                    } else error("Returned data is not valid", "Returned type is " + changeEnumStyle(tostring(mapInfo.GetType())));
                 }
             }
 

--- a/src/UI.as
+++ b/src/UI.as
@@ -6,13 +6,45 @@ void RenderInterface() {
 	if (!menu_visibility) {
 		return;
 	}
-	if (UI::Begin(MXColor + Icons::Random + " \\$z"+name+"\\$555 (v"+Meta::ExecutingPlugin().get_Version()+" by "+Meta::ExecutingPlugin().get_Author()+")", menu_visibility, 2097154)) {
-        UI::SetWindowSize(vec2(650, Setting_WindowSize_h));
-        RenderHeader();
-        RenderBody();
-        RenderFooter();
-	}
-	UI::End();
+    if (Setting_Window_Minimal) {
+        if (UI::Begin(MXColor + Icons::Random, menu_visibility, 2097186)) {
+            UI::SetWindowSize(vec2(200, 100));
+#if TMNEXT
+            if (!Permissions::PlayLocalMap()) UI::Text("\\$f00"+Icons::Times+" Missing permissions!");
+            else {
+#elif MP4
+            if (!isTitePackLoaded()) UI::Text("\\$f00"+Icons::Times+" \\zNo titlepack loaded!");
+            else {
+#endif
+                if (!isSearching) {
+                    UI::PushStyleColor(UI::Col::Button, vec4(0, 0.443, 0, 0.8));
+                    UI::PushStyleColor(UI::Col::ButtonHovered, vec4(0, 0.443, 0, 1));
+                    UI::PushStyleColor(UI::Col::ButtonActive, vec4(0, 0.443, 0, 0.6));
+                    if (UI::Button(Icons::Random+" Start")) {
+                        RandomMapProcess = true;
+                        isSearching = !isSearching;
+                    }
+                } else {
+                    UI::PushStyleColor(UI::Col::Button, vec4(0.443, 0, 0, 0.8));
+                    UI::PushStyleColor(UI::Col::ButtonHovered, vec4(0.443, 0, 0, 1));
+                    UI::PushStyleColor(UI::Col::ButtonActive, vec4(0.443, 0, 0, 0.6));
+                    if(UI::Button(Icons::Times + " Stop")){
+                        RandomMapProcess = true;
+                        isSearching = !isSearching;
+                    }
+                }
+                UI::PopStyleColor(3);
+            }
+        UI::End();
+    } else {
+        if (UI::Begin(MXColor + Icons::Random + " \\$z"+name+"\\$555 (v"+Meta::ExecutingPlugin().get_Version()+" by "+Meta::ExecutingPlugin().get_Author()+")", menu_visibility, 2097154)) {
+            UI::SetWindowSize(vec2(650, Setting_WindowSize_h));
+            RenderHeader();
+            RenderBody();
+            RenderFooter();
+        }
+        UI::End();
+    }
 }
 
 void RenderHeader() {

--- a/src/UI.as
+++ b/src/UI.as
@@ -35,7 +35,8 @@ void RenderInterface() {
                 }
                 UI::PopStyleColor(3);
             }
-        UI::End();
+            UI::End();
+        }
     } else {
         if (UI::Begin(MXColor + Icons::Random + " \\$z"+name+"\\$555 (v"+Meta::ExecutingPlugin().get_Version()+" by "+Meta::ExecutingPlugin().get_Author()+")", menu_visibility, 2097154)) {
             UI::SetWindowSize(vec2(650, Setting_WindowSize_h));

--- a/src/UI.as
+++ b/src/UI.as
@@ -3,8 +3,9 @@ int rand = 0;
 
 void RenderInterface() {
     Dialogs::RenderInterface();
-	if (Setting_Window_Minimal) {
-        if (UI::Begin(MXColor + Icons::Random, Setting_Window_Minimal, 2097154+32+64)) {
+    if (!Setting_Window_Show) return;
+    if (Setting_Window_Type == WindowType::Minimal){
+        if (UI::Begin(MXColor + Icons::Random, Setting_Window_Show, 2097154+32+64)) {
 #if TMNEXT
             if (!Permissions::PlayLocalMap()) UI::Text("\\$f00"+Icons::Times+" Missing permissions!");
             else {
@@ -33,10 +34,9 @@ void RenderInterface() {
             }
             UI::End();
         }
-    }
-    if (Setting_Window_Show) {
+    } else if (Setting_Window_Type == WindowType::Full) {
         if (UI::Begin(MXColor + Icons::Random + " \\$z"+name+"\\$555 (v"+Meta::ExecutingPlugin().get_Version()+" by "+Meta::ExecutingPlugin().get_Author()+")", Setting_Window_Show, 2097154)) {
-            UI::SetWindowSize(vec2(650, Setting_WindowSize_h));
+            UI::SetWindowSize(vec2(Setting_WindowSize_w, Setting_WindowSize_h));
             RenderHeader();
             RenderBody();
             RenderFooter();

--- a/src/UI.as
+++ b/src/UI.as
@@ -58,17 +58,7 @@ void RenderHeader() {
                     RandomMapProcess = true;
                     isSearching = !isSearching;
                 } else {
-                    Json::Value mapInfo = GetMap(inputMapID);
-                    if (mapInfo.GetType() == Json::Type::Object) {
-#if MP4
-                        if (mapInfo["TitlePack"] == getTitlePack()) {
-#endif
-                            CreatePlayedMapJson(mapInfo);
-                            loadMapId = inputMapID;
-#if MP4
-                        } else error("You can't play a map from a different titlepack", mapInfo["TitlePack"]);
-#endif
-                    } else error("Returned data is not valid", "Returned type is " + changeEnumStyle(tostring(mapInfo.GetType())));
+                    loadMapIdWithJson = inputMapID;
                 }
             }
 

--- a/src/UI.as
+++ b/src/UI.as
@@ -3,24 +3,20 @@ int rand = 0;
 
 void RenderInterface() {
     Dialogs::RenderInterface();
-	if (!menu_visibility) {
-		return;
-	}
-    if (Setting_Window_Minimal) {
-        if (UI::Begin(MXColor + Icons::Random, menu_visibility, 2097186)) {
-            UI::SetWindowSize(vec2(200, 100));
+	if (Setting_Window_Minimal) {
+        if (UI::Begin(MXColor + Icons::Random, Setting_Window_Minimal, 2097154+32+64+1)) {
 #if TMNEXT
             if (!Permissions::PlayLocalMap()) UI::Text("\\$f00"+Icons::Times+" Missing permissions!");
             else {
 #elif MP4
-            if (!isTitePackLoaded()) UI::Text("\\$f00"+Icons::Times+" \\zNo titlepack loaded!");
+            if (!isTitePackLoaded()) UI::Text("\\$f00"+Icons::Times+" \\$zNo titlepack loaded!");
             else {
 #endif
                 if (!isSearching) {
                     UI::PushStyleColor(UI::Col::Button, vec4(0, 0.443, 0, 0.8));
                     UI::PushStyleColor(UI::Col::ButtonHovered, vec4(0, 0.443, 0, 1));
                     UI::PushStyleColor(UI::Col::ButtonActive, vec4(0, 0.443, 0, 0.6));
-                    if (UI::Button(Icons::Random+" Start")) {
+                    if (UI::Button(Icons::Random+" Start " + shortMXName + " random map")) {
                         RandomMapProcess = true;
                         isSearching = !isSearching;
                     }
@@ -28,7 +24,7 @@ void RenderInterface() {
                     UI::PushStyleColor(UI::Col::Button, vec4(0.443, 0, 0, 0.8));
                     UI::PushStyleColor(UI::Col::ButtonHovered, vec4(0.443, 0, 0, 1));
                     UI::PushStyleColor(UI::Col::ButtonActive, vec4(0.443, 0, 0, 0.6));
-                    if(UI::Button(Icons::Times + " Stop")){
+                    if(UI::Button(Icons::Times + " Stop searching")){
                         RandomMapProcess = true;
                         isSearching = !isSearching;
                     }
@@ -37,8 +33,9 @@ void RenderInterface() {
             }
             UI::End();
         }
-    } else {
-        if (UI::Begin(MXColor + Icons::Random + " \\$z"+name+"\\$555 (v"+Meta::ExecutingPlugin().get_Version()+" by "+Meta::ExecutingPlugin().get_Author()+")", menu_visibility, 2097154)) {
+    }
+    if (Setting_Window_Show) {
+        if (UI::Begin(MXColor + Icons::Random + " \\$z"+name+"\\$555 (v"+Meta::ExecutingPlugin().get_Version()+" by "+Meta::ExecutingPlugin().get_Author()+")", Setting_Window_Show, 2097154)) {
             UI::SetWindowSize(vec2(650, Setting_WindowSize_h));
             RenderHeader();
             RenderBody();


### PR DESCRIPTION
- **Added Minimal Window mode**, it removes all the unuseful part and focus you on the RMC, it had just a button "start search" (PS: You need to let the Openplanet overlay open)
- Fixed random crashes where Map Style was null
- Added window width resize (for the main window)
- For TM2020, Requests will not return Royal maps or any else, it will return normal Race maps (it's rare but it can)