### PR TITLE
prevent loading shootmania maps

### DIFF
--- a/src/Methods.as
+++ b/src/Methods.as
@@ -149,6 +149,12 @@ Json::Value GetRandomMap() {
     Net::HttpRequest req;
     req.Method = Net::HttpMethod::Get;
     req.Url = "https://"+TMXURL+"/mapsearch2/search?api=on&random=1";
+
+#if TMNEXT
+    // prevent loading shootmania maps
+    req.Url += "&vehicles=1";
+#endif
+
     if (RMCStarted){
         req.Url += "&etags=23%2C37";
         req.Url += "&lengthop=1";


### PR DESCRIPTION
This change limits the search of random maps on TM2020 in order to prevent loading shootmania-style "CharacterPilot" maps. That scenario usually leads to run-ending crashes, so its better to just filter them out.

It seems like this filter excludes about 30 maps from TMX total. You can't search for them directly (vehicles=-1 filter doesn't work), but this is the difference in numbers of maps between search with and without the filter applied.

Example of such map: https://trackmania.exchange/maps/1716/cactus
Here is a world record run that got ended because of this: https://www.twitch.tv/videos/1157699620 The crash happens in last couple of minutes of the stream.

