### PR TITLE
1.6

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -5,7 +5,7 @@ category = "TMX"
 perms = "paid"
 siteid = 124
 
-version = "1.5.1"
+version = "1.6"
 
 [script]
 imports = [ "Icons.as", "Permissions.as", "Dialogs.as" ]

--- a/src/Main.as
+++ b/src/Main.as
@@ -24,6 +24,7 @@ void Main()
     while (true){
         yield();
         startnew(SearchCoroutine);
+        startnew(TimerYield);
         if (loadMapId != 0) {
 #if TMNEXT
             ClosePauseMenu();

--- a/src/Methods.as
+++ b/src/Methods.as
@@ -113,16 +113,17 @@ int GetCurrentMapMedal(){
 
         if (GamePlayground.GameTerminals.get_Length() > 0){
 #if MP4
-            CTrackManiaPlayer@ player = cast<CTrackManiaPlayer>(GamePlayground.GameTerminals[0].GUIPlayer);
-            if (player.RaceState == CTrackManiaPlayer::ERaceState::Finished) time = player.CurCheckpointRaceTime;
-            else time = -1;
+            CGameCtnPlayground@ GameCtnPlayground = cast<CGameCtnPlayground>(app.CurrentPlayground);
+            if (GameCtnPlayground.PlayerRecordedGhost !is null){
+                time = GameCtnPlayground.PlayerRecordedGhost.RaceTime;
+            } else time = -1;
 #elif TMNEXT
             CSmArenaRulesMode@ PlaygroundScript = cast<CSmArenaRulesMode>(GetApp().PlaygroundScript);
             CSmPlayer@ player = cast<CSmPlayer>(GamePlayground.GameTerminals[0].ControlledPlayer);
             if (PlaygroundScript !is null && player !is null) {
                 auto ghost = PlaygroundScript.Ghost_RetrieveFromPlayer(player.ScriptAPI);
                 if (ghost !is null) {
-                    if (ghost.Result.Time > 0 && ghost.Result.Time < 4294967295) time = Text::ParseInt(Text::Format("%", ghost.Result.Time));
+                    if (ghost.Result.Time > 0 && ghost.Result.Time < 4294967295) time = ghost.Result.Time;
                     PlaygroundScript.DataFileMgr.Ghost_Release(ghost.Id);
                 }
             }

--- a/src/Methods.as
+++ b/src/Methods.as
@@ -147,15 +147,14 @@ Json::Value GetRandomMap() {
     req.Method = Net::HttpMethod::Get;
     req.Url = "https://"+TMXURL+"/mapsearch2/search?api=on&random=1";
 
-#if TMNEXT
-    // prevent loading shootmania maps
-    req.Url += "&vehicles=1";
-#endif
-
     if (RMCStarted){
         req.Url += "&etags=23%2C37";
         req.Url += "&lengthop=1";
         req.Url += "&length=13";
+#if TMNEXT
+        // prevent loading shootmania maps
+        req.Url += "&vehicles=1";
+#endif
     } else {
         req.Url += "&etags=37";
         if (Setting_MapLength != MapLength::Anything){

--- a/src/Methods.as
+++ b/src/Methods.as
@@ -112,21 +112,22 @@ int GetCurrentMapMedal(){
         int time = -1;
 
         if (GamePlayground.GameTerminals.get_Length() > 0){
-// #if MP4
+#if MP4
             CGameCtnPlayground@ GameCtnPlayground = cast<CGameCtnPlayground>(app.CurrentPlayground);
-            if (GameCtnPlayground.PlayerRecordedGhost !is null) time = GameCtnPlayground.PlayerRecordedGhost.RaceTime;
-            else time = -1;
-// #elif TMNEXT
-//             CSmArenaRulesMode@ PlaygroundScript = cast<CSmArenaRulesMode>(GetApp().PlaygroundScript);
-//             CSmPlayer@ player = cast<CSmPlayer>(GamePlayground.GameTerminals[0].ControlledPlayer);
-//             if (PlaygroundScript !is null && player !is null) {
-//                 auto ghost = PlaygroundScript.Ghost_RetrieveFromPlayer(player.ScriptAPI);
-//                 if (ghost !is null) {
-//                     if (ghost.Result.Time > 0 && ghost.Result.Time < 4294967295) time = ghost.Result.Time;
-//                     PlaygroundScript.DataFileMgr.Ghost_Release(ghost.Id);
-//                 }
-//             }
-// #endif
+            if (GameCtnPlayground.PlayerRecordedGhost !is null){
+                time = GameCtnPlayground.PlayerRecordedGhost.RaceTime;
+            } else time = -1;
+#elif TMNEXT
+            CSmArenaRulesMode@ PlaygroundScript = cast<CSmArenaRulesMode>(GetApp().PlaygroundScript);
+            CSmPlayer@ player = cast<CSmPlayer>(GamePlayground.GameTerminals[0].ControlledPlayer);
+            if (PlaygroundScript !is null && player !is null) {
+                auto ghost = PlaygroundScript.Ghost_RetrieveFromPlayer(player.ScriptAPI);
+                if (ghost !is null) {
+                    if (ghost.Result.Time > 0 && ghost.Result.Time < 4294967295) time = ghost.Result.Time;
+                    PlaygroundScript.DataFileMgr.Ghost_Release(ghost.Id);
+                }
+            }
+#endif
             medal = 0;
             if (time != -1){
                 if(time <= authorTime) medal = 4;

--- a/src/Methods.as
+++ b/src/Methods.as
@@ -118,17 +118,14 @@ int GetCurrentMapMedal(){
             else time = -1;
 #elif TMNEXT
             CSmArenaRulesMode@ PlaygroundScript = cast<CSmArenaRulesMode>(GetApp().PlaygroundScript);
-            if (PlaygroundScript !is null) {
-                CSmPlayer@ player = cast<CSmPlayer>(GamePlayground.GameTerminals[0].ControlledPlayer);
-                if (player !is null) {
-                    auto ghost = PlaygroundScript.Ghost_RetrieveFromPlayer(player.ScriptAPI);
-                    if (ghost !is null) {
-                        if (ghost.Result.Time != 4294967295) time = ghost.Result.Time;
-                        else time = -1;
-                        PlaygroundScript.DataFileMgr.Ghost_Release(ghost.Id);
-                    } else time = -1;
-                } else time = -1;
-            } else time = -1;
+            CSmPlayer@ player = cast<CSmPlayer>(GamePlayground.GameTerminals[0].ControlledPlayer);
+            if (PlaygroundScript !is null && player !is null) {
+                auto ghost = PlaygroundScript.Ghost_RetrieveFromPlayer(player.ScriptAPI);
+                if (ghost !is null) {
+                    if (ghost.Result.Time > 0 && ghost.Result.Time != 4294967295) time = Text::ParseInt(Text::Format("%", ghost.Result.Time));
+                    PlaygroundScript.DataFileMgr.Ghost_Release(ghost.Id);
+                }
+            }
 #endif
             medal = 0;
             if (time != -1){

--- a/src/Methods.as
+++ b/src/Methods.as
@@ -63,7 +63,7 @@ string getTitlePack(bool full = false)
 {
     if (isTitePackLoaded()){
         auto appMP = cast<CGameManiaPlanet>(GetApp());
-        if (full) return appMP.LoadedManiaTitle.TitleId;
+        if (full) return appMP.LoadedManiaTitle.TitleId.SubStr(0, appMP.LoadedManiaTitle.TitleId.IndexOf("@"));
         else return appMP.LoadedManiaTitle.BaseTitleId;
     } else {
         return "";
@@ -167,7 +167,7 @@ Json::Value GetRandomMap() {
     }
     
 #if MP4
-    req.Url += "&tpack=" + getTitlePack() + "&gv=1";
+    req.Url += "&tpack=" + getTitlePack(true) + "&gv=1";
 #endif
     dictionary@ Headers = dictionary();
     Headers["Accept"] = "application/json";

--- a/src/Methods.as
+++ b/src/Methods.as
@@ -112,22 +112,21 @@ int GetCurrentMapMedal(){
         int time = -1;
 
         if (GamePlayground.GameTerminals.get_Length() > 0){
-#if MP4
+// #if MP4
             CGameCtnPlayground@ GameCtnPlayground = cast<CGameCtnPlayground>(app.CurrentPlayground);
-            if (GameCtnPlayground.PlayerRecordedGhost !is null){
-                time = GameCtnPlayground.PlayerRecordedGhost.RaceTime;
-            } else time = -1;
-#elif TMNEXT
-            CSmArenaRulesMode@ PlaygroundScript = cast<CSmArenaRulesMode>(GetApp().PlaygroundScript);
-            CSmPlayer@ player = cast<CSmPlayer>(GamePlayground.GameTerminals[0].ControlledPlayer);
-            if (PlaygroundScript !is null && player !is null) {
-                auto ghost = PlaygroundScript.Ghost_RetrieveFromPlayer(player.ScriptAPI);
-                if (ghost !is null) {
-                    if (ghost.Result.Time > 0 && ghost.Result.Time < 4294967295) time = ghost.Result.Time;
-                    PlaygroundScript.DataFileMgr.Ghost_Release(ghost.Id);
-                }
-            }
-#endif
+            if (GameCtnPlayground.PlayerRecordedGhost !is null) time = GameCtnPlayground.PlayerRecordedGhost.RaceTime;
+            else time = -1;
+// #elif TMNEXT
+//             CSmArenaRulesMode@ PlaygroundScript = cast<CSmArenaRulesMode>(GetApp().PlaygroundScript);
+//             CSmPlayer@ player = cast<CSmPlayer>(GamePlayground.GameTerminals[0].ControlledPlayer);
+//             if (PlaygroundScript !is null && player !is null) {
+//                 auto ghost = PlaygroundScript.Ghost_RetrieveFromPlayer(player.ScriptAPI);
+//                 if (ghost !is null) {
+//                     if (ghost.Result.Time > 0 && ghost.Result.Time < 4294967295) time = ghost.Result.Time;
+//                     PlaygroundScript.DataFileMgr.Ghost_Release(ghost.Id);
+//                 }
+//             }
+// #endif
             medal = 0;
             if (time != -1){
                 if(time <= authorTime) medal = 4;

--- a/src/Methods.as
+++ b/src/Methods.as
@@ -111,31 +111,29 @@ int GetCurrentMapMedal(){
         int bronzeTime = map.TMObjective_BronzeTime;
         int time = -1;
 
-        if (GamePlayground.GameTerminals.get_Length() > 0){
 #if MP4
-            CGameCtnPlayground@ GameCtnPlayground = cast<CGameCtnPlayground>(app.CurrentPlayground);
-            if (GameCtnPlayground.PlayerRecordedGhost !is null){
-                time = GameCtnPlayground.PlayerRecordedGhost.RaceTime;
-            } else time = -1;
+        CGameCtnPlayground@ GameCtnPlayground = cast<CGameCtnPlayground>(app.CurrentPlayground);
+        if (GameCtnPlayground.PlayerRecordedGhost !is null){
+            time = GameCtnPlayground.PlayerRecordedGhost.RaceTime;
+        } else time = -1;
 #elif TMNEXT
-            CSmArenaRulesMode@ PlaygroundScript = cast<CSmArenaRulesMode>(GetApp().PlaygroundScript);
-            CSmPlayer@ player = cast<CSmPlayer>(GamePlayground.GameTerminals[0].ControlledPlayer);
-            if (PlaygroundScript !is null && player !is null) {
-                auto ghost = PlaygroundScript.Ghost_RetrieveFromPlayer(player.ScriptAPI);
-                if (ghost !is null) {
-                    if (ghost.Result.Time > 0 && ghost.Result.Time < 4294967295) time = ghost.Result.Time;
-                    PlaygroundScript.DataFileMgr.Ghost_Release(ghost.Id);
-                }
+        CSmArenaRulesMode@ PlaygroundScript = cast<CSmArenaRulesMode>(app.PlaygroundScript);
+        CSmPlayer@ player = cast<CSmPlayer>(GamePlayground.GameTerminals[0].ControlledPlayer);
+        if (PlaygroundScript !is null && player !is null) {
+            auto ghost = PlaygroundScript.Ghost_RetrieveFromPlayer(player.ScriptAPI);
+            if (ghost !is null) {
+                if (ghost.Result.Time > 0 && ghost.Result.Time < 4294967295) time = ghost.Result.Time;
+                PlaygroundScript.DataFileMgr.Ghost_Release(ghost.Id);
             }
+        } else time = -1;
 #endif
-            medal = 0;
-            if (time != -1){
-                if(time <= authorTime) medal = 4;
-                else if(time <= goldTime) medal = 3;
-                else if(time <= silverTime) medal = 2;
-                else if(time <= bronzeTime) medal = 1;
-                else medal = 0;
-            }
+        medal = 0;
+        if (time != -1){
+            if(time <= authorTime) medal = 4;
+            else if(time <= goldTime) medal = 3;
+            else if(time <= silverTime) medal = 2;
+            else if(time <= bronzeTime) medal = 1;
+            else medal = 0;
         }
     }
     return medal;

--- a/src/Methods.as
+++ b/src/Methods.as
@@ -122,7 +122,7 @@ int GetCurrentMapMedal(){
             if (PlaygroundScript !is null && player !is null) {
                 auto ghost = PlaygroundScript.Ghost_RetrieveFromPlayer(player.ScriptAPI);
                 if (ghost !is null) {
-                    if (ghost.Result.Time > 0 && ghost.Result.Time != 4294967295) time = Text::ParseInt(Text::Format("%", ghost.Result.Time));
+                    if (ghost.Result.Time > 0 && ghost.Result.Time < 4294967295) time = Text::ParseInt(Text::Format("%", ghost.Result.Time));
                     PlaygroundScript.DataFileMgr.Ghost_Release(ghost.Id);
                 }
             }

--- a/src/Methods.as
+++ b/src/Methods.as
@@ -169,6 +169,7 @@ Json::Value GetRandomMap() {
 #if MP4
     req.Url += "&tpack=" + getTitlePack(true) + "&gv=1";
 #endif
+    log("Request URL: " + req.Url);
     dictionary@ Headers = dictionary();
     Headers["Accept"] = "application/json";
     Headers["Content-Type"] = "application/json";

--- a/src/Methods.as
+++ b/src/Methods.as
@@ -118,13 +118,15 @@ int GetCurrentMapMedal(){
         } else time = -1;
 #elif TMNEXT
         CSmArenaRulesMode@ PlaygroundScript = cast<CSmArenaRulesMode>(app.PlaygroundScript);
-        CSmPlayer@ player = cast<CSmPlayer>(GamePlayground.GameTerminals[0].ControlledPlayer);
-        if (PlaygroundScript !is null && player !is null) {
-            auto ghost = PlaygroundScript.Ghost_RetrieveFromPlayer(player.ScriptAPI);
-            if (ghost !is null) {
-                if (ghost.Result.Time > 0 && ghost.Result.Time < 4294967295) time = ghost.Result.Time;
-                PlaygroundScript.DataFileMgr.Ghost_Release(ghost.Id);
-            }
+        if (PlaygroundScript !is null && GamePlayground.GameTerminals.get_Length() > 0) {
+            CSmPlayer@ player = cast<CSmPlayer>(GamePlayground.GameTerminals[0].ControlledPlayer);
+            if (GamePlayground.GameTerminals[0].UISequence_Current == CGameTerminal::ESGamePlaygroundUIConfig__EUISequence::Finish && player !is null) {
+                auto ghost = PlaygroundScript.Ghost_RetrieveFromPlayer(player.ScriptAPI);
+                if (ghost !is null) {
+                    if (ghost.Result.Time > 0 && ghost.Result.Time < 4294967295) time = ghost.Result.Time;
+                    PlaygroundScript.DataFileMgr.Ghost_Release(ghost.Id);
+                } else time = -1;
+            } else time = -1;
         } else time = -1;
 #endif
         medal = 0;

--- a/src/Settings.as
+++ b/src/Settings.as
@@ -80,7 +80,7 @@ RMCGoal Setting_RMC_Goal = RMCGoal::Author;
 [Setting name="Display the current map name, author and style (according to MX) on the RMC timer" category="Random Map Challenge"]
 bool Setting_RMC_DisplayCurrentMap = true;
 
-[Setting name="Automatically switch map when got author medal" category="Random Map Challenge"]
+[Setting name="Automatically switch map when got goal time" category="Random Map Challenge"]
 bool Setting_RMC_AutoSwitch = true;
 
 [Setting name="Automatically quits the map when the timer is up" category="Random Map Challenge"]

--- a/src/TimerUI.as
+++ b/src/TimerUI.as
@@ -106,16 +106,14 @@ void startTimer() {
     endTime = startTime + (timer*60*1000);
 }
 
-void Update(float dt) {
-    if (startTime < 0 || !timerStarted) {
-        return;
-    } else {
+void TimerYield() {
+    if (startTime > 0 || timerStarted) {
         if (!isPaused){
             CGameCtnChallenge@ currentMap = cast<CGameCtnChallenge>(GetApp().RootMap);
             if (currentMap !is null) {
                 CGameCtnChallengeInfo@ currentMapInfo = currentMap.MapInfo;
                 if (currentMapInfo !is null) {
-                    if (currentMapInfo.MapUid == RecentlyPlayedMaps[0]["UID"]) {
+                    if (RecentlyPlayedMaps.Length > 0 && currentMapInfo.MapUid == RecentlyPlayedMaps[0]["UID"]) {
                         startTime = Time::get_Now();
 
                         if (startTime > endTime) {
@@ -170,7 +168,7 @@ void Update(float dt) {
                 UI::ShowNotification("\\$071" + Icons::Trophy + " You got "+changeEnumStyle(tostring(Setting_RMC_Goal))+" time!", descTxt);
             }
         }
-        if (GetCurrentMapMedal() >= lowerMedalInt && !gotMedalOnceNotif && Setting_RMC_Mode == RMCMode::Challenge && Setting_RMC_Goal != RMCGoal::Bronze){            
+        if (GetCurrentMapMedal() >= lowerMedalInt && GetCurrentMapMedal() < Setting_RMC_Goal && !gotMedalOnceNotif && Setting_RMC_Mode == RMCMode::Challenge && Setting_RMC_Goal != RMCGoal::Bronze){            
             UI::ShowNotification("\\$db4" + Icons::Trophy + " You got "+lowerMedalName+" medal", "You can take the medal and skip the map");
             gotMedalOnceNotif = true;
         }
@@ -241,7 +239,7 @@ void RenderCurrentMap(){
     if (currentMap !is null) {
         CGameCtnChallengeInfo@ currentMapInfo = currentMap.MapInfo;
         if (currentMapInfo !is null) {
-            if (currentMapInfo.MapUid == RecentlyPlayedMaps[0]["UID"]) {
+            if (RecentlyPlayedMaps.Length > 0 && currentMapInfo.MapUid == RecentlyPlayedMaps[0]["UID"]) {
                 UI::Text("Current Map:");
                 if (RecentlyPlayedMaps.get_Length() > 0){
                     string mapName = RecentlyPlayedMaps[0]["name"];

--- a/src/TimerUI.as
+++ b/src/TimerUI.as
@@ -188,8 +188,9 @@ void RenderTimer(){
 
 string FormatTimer(int time) {
     int hundreths = time % 1000 / 10;
-    int hours = time / (60 * 60 * 1000);
-    int minutes = time / (60 * 1000) % 60;
+    time /= 1000;
+    int hours = time / 3600;
+    int minutes = (time / 60) % 60;
     int seconds = time % 60;
 
     return (hours != 0 ? Text::Format("%02d", hours) + ":" : "" ) + (minutes != 0 ? Text::Format("%02d", minutes) + ":" : "") + Text::Format("%02d", seconds) + "." + Text::Format("%02d", hundreths);

--- a/src/TimerUI.as
+++ b/src/TimerUI.as
@@ -101,47 +101,47 @@ void startTimer() {
 void Update(float dt) {
     if (startTime < 0 || !timerStarted) {
         return;
-    }
+    } else {
+        if (!isPaused){
+            CGameCtnChallenge@ currentMap = cast<CGameCtnChallenge>(GetApp().RootMap);
+            if (currentMap !is null) {
+                CGameCtnChallengeInfo@ currentMapInfo = currentMap.MapInfo;
+                if (currentMapInfo !is null) {
+                    if (currentMapInfo.MapUid == RecentlyPlayedMaps[0]["UID"]) {
+                        startTime = Time::get_Now();
 
-    if (timerStarted && !isPaused){
-        CGameCtnChallenge@ currentMap = cast<CGameCtnChallenge>(GetApp().RootMap);
-        if (currentMap !is null) {
-            CGameCtnChallengeInfo@ currentMapInfo = currentMap.MapInfo;
-            if (currentMapInfo.MapUid == RecentlyPlayedMaps[0]["UID"]) {
-                startTime = Time::get_Now();
-
-                if (startTime > endTime) {
-                    startTime = -1;
-                    timerStarted = false;
-                    RMCStarted = false;
-                    displayTimer = false;
-                    if (Setting_RMC_Mode == RMCMode::Challenge) UI::ShowNotification("\\$0f0Random Map Challenge ended!", "You got "+ authorCount + " author and "+ goldCount + " gold medals!");
-                    else if (Setting_RMC_Mode == RMCMode::Survival) UI::ShowNotification("\\$0f0Random Map Survival ended!", "You got "+ authorCount + " author medals and " + survivalSkips + " skips.");
-                    if (Setting_RMC_ExitMapOnEndTime){
-                        CTrackMania@ app = cast<CTrackMania>(GetApp());
-                        app.BackToMainMenu();
-                    }
+                        if (startTime > endTime) {
+                            startTime = -1;
+                            timerStarted = false;
+                            RMCStarted = false;
+                            displayTimer = false;
+                            if (Setting_RMC_Mode == RMCMode::Challenge) UI::ShowNotification("\\$0f0Random Map Challenge ended!", "You got "+ authorCount + " author and "+ goldCount + " gold medals!");
+                            else if (Setting_RMC_Mode == RMCMode::Survival) UI::ShowNotification("\\$0f0Random Map Survival ended!", "You got "+ authorCount + " author medals and " + survivalSkips + " skips.");
+                            if (Setting_RMC_ExitMapOnEndTime){
+                                CTrackMania@ app = cast<CTrackMania>(GetApp());
+                                app.BackToMainMenu();
+                            }
+                        }
+                    } else RecentlyPlayedMaps = loadRecentlyPlayed();
                 }
-            } else RecentlyPlayedMaps = loadRecentlyPlayed();
+            }
+        } else {
+            startTime = Time::get_Now() - (Time::get_Now() - startTime);
         }
-    } else if (timerStarted && isPaused) {
-        startTime = Time::get_Now() - (Time::get_Now() - startTime);
-    }
 
-    if (timerStarted){
-        if (Setting_RMC_Goal ==  RMCGoal::Author) {
+        if (Setting_RMC_Goal == RMCGoal::Author) {
             actualMedalName = "Author";
             lowerMedalName = "Gold";
             lowerMedalInt = 3;
-        } else if (Setting_RMC_Goal ==  RMCGoal::Gold) {
+        } else if (Setting_RMC_Goal == RMCGoal::Gold) {
             actualMedalName = "Gold";
             lowerMedalName = "Silver";
             lowerMedalInt = 2;
-        } else if (Setting_RMC_Goal ==  RMCGoal::Silver) {
+        } else if (Setting_RMC_Goal == RMCGoal::Silver) {
             actualMedalName = "Silver";
             lowerMedalName = "Bronze";
             lowerMedalInt = 1;
-        } else if (Setting_RMC_Goal ==  RMCGoal::Bronze) {
+        } else if (Setting_RMC_Goal == RMCGoal::Bronze) {
             actualMedalName = "Bronze";
             lowerMedalName = "";
             lowerMedalInt = 0;
@@ -232,17 +232,19 @@ void RenderCurrentMap(){
     CGameCtnChallenge@ currentMap = cast<CGameCtnChallenge>(GetApp().RootMap);
     if (currentMap !is null) {
         CGameCtnChallengeInfo@ currentMapInfo = currentMap.MapInfo;
-        if (currentMapInfo.MapUid == RecentlyPlayedMaps[0]["UID"]) {
-            UI::Text("Current Map:");
-            if (RecentlyPlayedMaps.get_Length() > 0){
-                string mapName = RecentlyPlayedMaps[0]["name"];
-                string mapAuthor = RecentlyPlayedMaps[0]["author"];
-                string mapStyle = RecentlyPlayedMaps[0]["style"];
-                UI::Text("'" + mapName + "' by " + mapAuthor);
-                UI::Text("(Style: " + mapStyle + ")");
-            } else {
-                UI::Text(":( Map info unavailable");
-            }
+        if (currentMapInfo !is null) {
+            if (currentMapInfo.MapUid == RecentlyPlayedMaps[0]["UID"]) {
+                UI::Text("Current Map:");
+                if (RecentlyPlayedMaps.get_Length() > 0){
+                    string mapName = RecentlyPlayedMaps[0]["name"];
+                    string mapAuthor = RecentlyPlayedMaps[0]["author"];
+                    string mapStyle = RecentlyPlayedMaps[0]["style"];
+                    UI::Text("'" + mapName + "' by " + mapAuthor);
+                    UI::Text("(Style: " + mapStyle + ")");
+                } else {
+                    UI::Text(":( Map info unavailable");
+                }
+            } else RecentlyPlayedMaps = loadRecentlyPlayed();
         }
     } else {
         if (isPaused) UI::Text("Switching map...");

--- a/src/TimerUI.as
+++ b/src/TimerUI.as
@@ -188,9 +188,8 @@ void RenderTimer(){
 
 string FormatTimer(int time) {
     int hundreths = time % 1000 / 10;
-    time /= 1000;
-    int hours = time / 3600;
-    int minutes = (time / 60) % 60;
+    int hours = time / (60 * 60 * 1000);
+    int minutes = time / (60 * 1000) % 60;
     int seconds = time % 60;
 
     return (hours != 0 ? Text::Format("%02d", hours) + ":" : "" ) + (minutes != 0 ? Text::Format("%02d", minutes) + ":" : "") + Text::Format("%02d", seconds) + "." + Text::Format("%02d", hundreths);

--- a/src/TimerUI.as
+++ b/src/TimerUI.as
@@ -64,9 +64,6 @@ void Render(){
         }
     } else {
         if (UI::Begin(windowTitle, Setting_RMC_DisplayTimer, TimerWindowFlags)){
-            if (!UI::IsOverlayShown()){
-                // UI::SetWindowSize(vec2(200, 180));
-            }
             if (UI::IsOverlayShown()){
                 UI::PushStyleColor(UI::Col::Button, vec4(0.443, 0, 0, 0.8));
                 UI::PushStyleColor(UI::Col::ButtonHovered, vec4(0.443, 0, 0, 1));

--- a/src/TimerUI.as
+++ b/src/TimerUI.as
@@ -132,30 +132,24 @@ void Update(float dt) {
     }
 
     if (timerStarted){
-        switch (Setting_RMC_Goal) {
-            case RMCGoal::Author:
-                actualMedalName = "Author";
-                lowerMedalName = "Gold";
-                lowerMedalInt = 3;
-            break;
-            case RMCGoal::Gold:
-                actualMedalName = "Gold";
-                lowerMedalName = "Silver";
-                lowerMedalInt = 2;
-            break;
-            case RMCGoal::Silver:
-                actualMedalName = "Silver";
-                lowerMedalName = "Bronze";
-                lowerMedalInt = 1;
-            break;
-            case RMCGoal::Bronze:
-                actualMedalName = "Bronze";
-            break;
-            default:
-                actualMedalName = "";
-                lowerMedalInt = 0;
-                lowerMedalName = "";
+        if (Setting_RMC_Goal ==  RMCGoal::Author) {
+            actualMedalName = "Author";
+            lowerMedalName = "Gold";
+            lowerMedalInt = 3;
+        } else if (Setting_RMC_Goal ==  RMCGoal::Gold) {
+            actualMedalName = "Gold";
+            lowerMedalName = "Silver";
+            lowerMedalInt = 2;
+        } else if (Setting_RMC_Goal ==  RMCGoal::Silver) {
+            actualMedalName = "Silver";
+            lowerMedalName = "Bronze";
+            lowerMedalInt = 1;
+        } else if (Setting_RMC_Goal ==  RMCGoal::Bronze) {
+            actualMedalName = "Bronze";
+            lowerMedalName = "";
+            lowerMedalInt = 0;
         }
+        
         if (GetCurrentMapMedal() >= Setting_RMC_Goal && !gotAuthor){
             gotAuthor = true;
             authorCount += 1;

--- a/src/TimerUI.as
+++ b/src/TimerUI.as
@@ -4,6 +4,7 @@ bool displayTimer = false;
 bool isPaused = false;
 bool gotMedalOnceNotif = false;
 bool gotAuthor = false;
+int realStartTime = -1;
 int startTime = -1;
 int endTime = -1;
 int authorCount = 0;
@@ -99,9 +100,11 @@ void Render(){
 }
 
 void startTimer() {
+    isPaused = false;
     timerStarted = true;
     int timer = 60;
     if (Setting_RMC_Mode == RMCMode::Survival) timer = 15;
+    realStartTime = Time::get_Now();
     startTime = Time::get_Now();
     endTime = startTime + (timer*60*1000);
 }
@@ -122,7 +125,7 @@ void TimerYield() {
                             RMCStarted = false;
                             displayTimer = false;
                             if (Setting_RMC_Mode == RMCMode::Challenge) UI::ShowNotification("\\$0f0Random Map Challenge ended!", "You got "+ authorCount + " author and "+ goldCount + " gold medals!");
-                            else if (Setting_RMC_Mode == RMCMode::Survival) UI::ShowNotification("\\$0f0Random Map Survival ended!", "You got "+ authorCount + " author medals and " + survivalSkips + " skips.");
+                            else if (Setting_RMC_Mode == RMCMode::Survival) UI::ShowNotification("\\$0f0Random Map Survival ended!", "You survived with a time of " + FormatTimer(realStartTime - startTime) + ".\nYou got "+ authorCount + " author medals and " + survivalSkips + " skips.");
                             if (Setting_RMC_ExitMapOnEndTime){
                                 CTrackMania@ app = cast<CTrackMania>(GetApp());
                                 app.BackToMainMenu();

--- a/src/TimerUI.as
+++ b/src/TimerUI.as
@@ -23,7 +23,15 @@ string lowerMedalName = "";
 string windowTitle = MXColor+Icons::HourglassO + " \\$zRMC";
 
 void Render(){
-    if (!Setting_RMC_DisplayTimer) return;
+    if (!Setting_RMC_DisplayTimer) {
+        // check if the timer is running
+        if (RMCStarted){
+            RMCStarted = false;
+            timerStarted = false;
+            displayTimer = false;
+        }
+        return;
+    }
 
     if (!UI::IsOverlayShown()) TimerWindowFlags = 2097154+32+64+8+1;
     else TimerWindowFlags = 2097154+32+64;

--- a/src/TimerUI.as
+++ b/src/TimerUI.as
@@ -258,6 +258,7 @@ void RenderPlayingButtons(){
         }
         UI::SameLine();
         if(UI::Button("Skip" + (Setting_RMC_Mode == RMCMode::Challenge && gotMedalOnceNotif && Setting_RMC_Goal != RMCGoal::Bronze ? " and take "+lowerMedalName+" medal": ""))) {
+            if (isPaused) isPaused = false;
             if (Setting_RMC_Mode == RMCMode::Challenge && gotMedalOnceNotif) {
                 goldCount += 1;
             }
@@ -273,14 +274,16 @@ void RenderPlayingButtons(){
             UI::SameLine();
             if(UI::Button("Survival Free Skip")) {
                 Dialogs::Question("\\$f00"+Icons::ExclamationTriangle+" \\$zFree skips is only if the map is impossible\nor the author time is over 5 minutes!\n\nAre you sure to skip?", function() {
+                    isPaused = false;
                     UI::ShowNotification("Please wait...", "Looking for another map");
                     startnew(loadMapRMC);
-                }, function(){});
+                }, function(){isPaused = false;});
             }
         }
         if (!Setting_RMC_AutoSwitch && gotAuthor){
             UI::SameLine();
             if(UI::Button("Next map")) {
+                if (isPaused) isPaused = false;
                 if (Setting_RMC_Mode == RMCMode::Survival) endTime += (3*60*1000);
                 startnew(loadMapRMC);
             }

--- a/src/TimerUI.as
+++ b/src/TimerUI.as
@@ -263,27 +263,38 @@ void RenderCurrentMap(){
 
 void RenderPlayingButtons(){
     if (timerStarted) {
-        if (UI::Button((isPaused ? "Resume" : "Pause") + " timer")) {
+        int HourGlassValue = Time::Stamp % 3;
+        string Hourglass = (HourGlassValue == 0 ? Icons::HourglassStart : (HourGlassValue == 1 ? Icons::HourglassHalf : Icons::HourglassEnd));
+        if (UI::Button((isPaused ? Icons::HourglassO + Icons::Play : Hourglass + Icons::Pause))) {
             if (isPaused) endTime = endTime + (Time::get_Now() - startTime);
             isPaused = !isPaused;
         }
         UI::SameLine();
-        if(UI::Button("Skip" + (Setting_RMC_Mode == RMCMode::Challenge && gotMedalOnceNotif && Setting_RMC_Goal != RMCGoal::Bronze ? " and take "+lowerMedalName+" medal": ""))) {
-            if (isPaused) isPaused = false;
-            if (Setting_RMC_Mode == RMCMode::Challenge && gotMedalOnceNotif) {
-                goldCount += 1;
+        if (mapsCount == 0 && !gotMedalOnceNotif) {
+            if (UI::Button(Icons::Repeat + " Restart")) {
+                if (isPaused) isPaused = false;
+                timerStarted = false;
+                displayTimer = false;
+                startnew(loadFirstMapRMC);
             }
-            if (Setting_RMC_Mode == RMCMode::Survival) {
-                endTime -= (2*60*1000);
-                survivalSkips += 1;
+        } else {
+            if(UI::Button(Icons::PlayCircleO + " Skip" + (Setting_RMC_Mode == RMCMode::Challenge && gotMedalOnceNotif && Setting_RMC_Goal != RMCGoal::Bronze ? " and take "+lowerMedalName+" medal": ""))) {
+                if (isPaused) isPaused = false;
+                if (Setting_RMC_Mode == RMCMode::Challenge && gotMedalOnceNotif) {
+                    goldCount += 1;
+                }
+                if (Setting_RMC_Mode == RMCMode::Survival) {
+                    endTime -= (2*60*1000);
+                    survivalSkips += 1;
+                }
+                UI::ShowNotification("Please wait...", "Looking for another map");
+                startnew(loadMapRMC);
             }
-            UI::ShowNotification("Please wait...", "Looking for another map");
-            startnew(loadMapRMC);
         }
 
         if (Setting_RMC_Mode == RMCMode::Survival){
             UI::SameLine();
-            if(UI::Button("Survival Free Skip")) {
+            if(UI::Button(Icons::PlayCircleO + " Survival Free Skip")) {
                 isPaused = true;
                 Dialogs::Question("\\$f00"+Icons::ExclamationTriangle+" \\$zFree skips is only if the map is impossible or broken.\n\nAre you sure to skip?", function() {
                     isPaused = false;
@@ -294,7 +305,7 @@ void RenderPlayingButtons(){
         }
         if (!Setting_RMC_AutoSwitch && gotAuthor){
             UI::SameLine();
-            if(UI::Button("Next map")) {
+            if(UI::Button(Icons::Play + " Next map")) {
                 if (isPaused) isPaused = false;
                 if (Setting_RMC_Mode == RMCMode::Survival) endTime += (3*60*1000);
                 startnew(loadMapRMC);

--- a/src/TimerUI.as
+++ b/src/TimerUI.as
@@ -273,7 +273,8 @@ void RenderPlayingButtons(){
         if (Setting_RMC_Mode == RMCMode::Survival){
             UI::SameLine();
             if(UI::Button("Survival Free Skip")) {
-                Dialogs::Question("\\$f00"+Icons::ExclamationTriangle+" \\$zFree skips is only if the map is impossible\nor the author time is over 5 minutes!\n\nAre you sure to skip?", function() {
+                isPaused = true;
+                Dialogs::Question("\\$f00"+Icons::ExclamationTriangle+" \\$zFree skips is only if the map is impossible or broken.\n\nAre you sure to skip?", function() {
                     isPaused = false;
                     UI::ShowNotification("Please wait...", "Looking for another map");
                     startnew(loadMapRMC);


### PR DESCRIPTION
- Fix medal names being numbers
- Space more medals counters
- Check if the map is correct while the timer runs (timer is in pause if the map does not match the first map in recent list)
- Using Ghosts to get the correct time (#20)
- Prevent loading CharacterPilot maps on RMC (#24)
- Remove AT >5min text on survival free skip text
- Fixed crash by adding a condition on UISequence (#23)
- Add survival total time
- Add icons on buttons
- And a lot of minor changes