### PR TITLE
1.7.1

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -5,7 +5,7 @@ category = "TMX"
 perms = "paid"
 siteid = 124
 
-version = "1.7"
+version = "1.7.1"
 
 [script]
 imports = [ "Icons.as", "Permissions.as", "Dialogs.as" ]

--- a/src/Settings.as
+++ b/src/Settings.as
@@ -92,9 +92,6 @@ enum RMCGoal {
 [Setting name="Goal" category="Random Map Challenge" description="The goal to get in a map to be counted, keep in mind that RMC rules accepts only Author Times at the moment"]
 RMCGoal Setting_RMC_Goal = RMCGoal::Author;
 
-[Setting name="Maximum timer on Survival mode (in minutes)" category="Random Map Challenge" min=2 max=60]
-int Setting_RMC_SurvivalMaxTime = 15;
-
 [Setting name="Display the current map name, author and style (according to MX) on the RMC timer" category="Random Map Challenge"]
 bool Setting_RMC_DisplayCurrentMap = true;
 
@@ -109,6 +106,9 @@ bool Setting_RMC_OnlySkip = false;
 
 [Setting name="Show the buttons when the Openplanet overlay is hidden" category="Random Map Challenge"]
 bool Setting_RMC_ShowBtns = true;
+
+[Setting name="Maximum timer on Survival mode (in minutes)" category="Random Map Challenge" min=2 max=60]
+int Setting_RMC_SurvivalMaxTime = 15;
 
 [Setting name="Announcements, Changelog and Rules API URL" category="Advanced" description="Change if you know what are you doing."]
 string Setting_API_URL = "https://greep.gq/api/mxrandom.json";

--- a/src/Settings.as
+++ b/src/Settings.as
@@ -107,14 +107,14 @@ bool Setting_RMC_ExitMapOnEndTime = false;
 [Setting name="Show Skip button on first map" category="Random Map Challenge"]
 bool Setting_RMC_OnlySkip = false;
 
-[Setting name="Show the buttons when the Openplanet overlay is hidden (requires Openplanet version 1.19.7)" category="Random Map Challenge"]
+[Setting name="Show the buttons when the Openplanet overlay is hidden" category="Random Map Challenge"]
 bool Setting_RMC_ShowBtns = true;
 
 [Setting name="Announcements, Changelog and Rules API URL" category="Advanced" description="Change if you know what are you doing."]
 string Setting_API_URL = "https://greep.gq/api/mxrandom.json";
 
 void OnSettingsLoad(Settings::Section& section){
-    if (OpenplanetVersionInt() < 1197 && Setting_RMC_ShowBtns){
+    if (OpenplanetVersionInt() < 1200 && Setting_RMC_ShowBtns){
         section.SetBool("Setting_RMC_ShowBtns", false);
         Setting_RMC_ShowBtns = false;
     }
@@ -125,8 +125,8 @@ void OnSettingsLoad(Settings::Section& section){
 void settingsCheckCoroutine(){
     while (true){
         yield();
-        if (OpenplanetVersionInt() < 1197 && Setting_RMC_ShowBtns) {
-            error("This setting requires at least Openplanet 1.19.7, please upgrade it!", "Setting_RMC_ShowBtns, OP version: " + Meta::OpenplanetVersion());
+        if (OpenplanetVersionInt() < 1200 && Setting_RMC_ShowBtns) {
+            error("This setting requires at least Openplanet 1.20.0, please upgrade it!", "Setting_RMC_ShowBtns, OP version: " + Meta::OpenplanetVersion());
             Setting_RMC_ShowBtns = false;
         }
     }

--- a/src/TimerUI.as
+++ b/src/TimerUI.as
@@ -440,7 +440,12 @@ void loadFirstMapRMC(){
     while (true){
         yield();
         CGamePlayground@ GamePlayground = cast<CGamePlayground>(GetApp().CurrentPlayground);
-        if (GamePlayground !is null){
+#if MP4
+        CTrackManiaPlayer@ player = cast<CTrackManiaPlayer>(GamePlayground.GameTerminals[0].GUIPlayer);
+#elif TMNEXT
+        CSmPlayer@ player = cast<CSmPlayer>(GamePlayground.GameTerminals[0].GUIPlayer);
+#endif
+        if (GamePlayground !is null && player !is null){
             goldCount = 0;
             authorCount = 0;
             survivalSkips = 0;
@@ -450,12 +455,11 @@ void loadFirstMapRMC(){
             UI::ShowNotification("\\$080Random Map "+ changeEnumStyle(tostring(Setting_RMC_Mode)) + " started!", "Good Luck!");
             displayTimer = true;
 #if MP4
-            CTrackManiaPlayer@ player = cast<CTrackManiaPlayer>(GamePlayground.GameTerminals[0].GUIPlayer);
             while (player.RaceState != CTrackManiaPlayer::ERaceState::Running){
                 yield();
             }
 #elif TMNEXT
-            while (GamePlayground.GameTerminals[0].UISequence_Current != CGameTerminal::ESGamePlaygroundUIConfig__EUISequence::Playing){
+            while (player.ScriptAPI.CurrentRaceTime < 0){
                 yield();
             }
 #endif

--- a/src/TimerUI.as
+++ b/src/TimerUI.as
@@ -440,31 +440,33 @@ void loadFirstMapRMC(){
     while (true){
         yield();
         CGamePlayground@ GamePlayground = cast<CGamePlayground>(GetApp().CurrentPlayground);
-#if MP4
-        CTrackManiaPlayer@ player = cast<CTrackManiaPlayer>(GamePlayground.GameTerminals[0].GUIPlayer);
-#elif TMNEXT
-        CSmPlayer@ player = cast<CSmPlayer>(GamePlayground.GameTerminals[0].GUIPlayer);
-#endif
-        if (GamePlayground !is null && player !is null){
+        if (GamePlayground !is null){
             goldCount = 0;
             authorCount = 0;
             survivalSkips = 0;
             mapsCount = 0;
             gotAuthor = false;
             gotMedalOnceNotif = false;
-            UI::ShowNotification("\\$080Random Map "+ changeEnumStyle(tostring(Setting_RMC_Mode)) + " started!", "Good Luck!");
+            if (!displayTimer) UI::ShowNotification("\\$080Random Map "+ changeEnumStyle(tostring(Setting_RMC_Mode)) + " started!", "Good Luck!");
             displayTimer = true;
 #if MP4
-            while (player.RaceState != CTrackManiaPlayer::ERaceState::Running){
-                yield();
-            }
+            CTrackManiaPlayer@ player = cast<CTrackManiaPlayer>(GamePlayground.GameTerminals[0].GUIPlayer);
 #elif TMNEXT
-            while (player.ScriptAPI.CurrentRaceTime < 0){
-                yield();
-            }
+            CSmPlayer@ player = cast<CSmPlayer>(GamePlayground.GameTerminals[0].GUIPlayer);
 #endif
-            startTimer();
-            break;
+            if (player !is null){
+#if MP4
+                while (player.RaceState != CTrackManiaPlayer::ERaceState::Running){
+                    yield();
+                }
+#elif TMNEXT
+                while (player.ScriptAPI.CurrentRaceTime < 0){
+                    yield();
+                }
+#endif
+                startTimer();
+                break;
+            }
         }
     }
 }


### PR DESCRIPTION
- Fixing start timer after the 3,2,1 countdown on Next
- Removing "requires OP 1.17" on setting and readjust check to version 1.20
- Moving survival maximum timer setting to very down because it's kinda useless
- If you have any reports or anything, send it now before Friday (date of release of the 1.7)!