### PR TITLE
fix: Timer Skip Survival

### DIFF
--- a/src/TimerUI.as
+++ b/src/TimerUI.as
@@ -330,8 +330,6 @@ void RenderPlayingButtons(){
                 }
                 if (Setting_RMC_Mode == RMCMode::Survival) {                    
                     survivalSkips += 1;
-
-                    if ((endTime - startTime) < (2*60*1000)) endTime = startTime + (2*60*1000);
                 }
                 log("RMC: Skipping map");
                 UI::ShowNotification("Please wait...", "Looking for another map");


### PR DESCRIPTION
Fix timer reseting to 2mins when skip is done with less than 2mins remaining when playing Survival mode